### PR TITLE
Fix chart cell to handle empty data sets

### DIFF
--- a/lib/kino_vega_lite/chart_cell.ex
+++ b/lib/kino_vega_lite/chart_cell.ex
@@ -444,7 +444,6 @@ defmodule KinoVegaLite.ChartCell do
     Enum.map(data, fn data -> data |> Enum.at(0) |> type_of() end)
   end
 
-
   defp infer_types({:rows, %{columns: columns}, data}) do
     case Enum.fetch(data, 0) do
       {:ok, row} -> Enum.map(row, &type_of/1)

--- a/lib/kino_vega_lite/chart_cell.ex
+++ b/lib/kino_vega_lite/chart_cell.ex
@@ -411,7 +411,7 @@ defmodule KinoVegaLite.ChartCell do
 
   defp columns_for(data) do
     with true <- implements?(Table.Reader, data),
-         data = {_, %{columns: columns}, _} <- Table.Reader.init(data),
+         data = {_, %{columns: [_ | _] = columns}, _} <- Table.Reader.init(data),
          true <- Enum.all?(columns, &implements?(String.Chars, &1)) do
       types = infer_types(data)
       Enum.zip_with(columns, types, fn column, type -> %{name: to_string(column), type: type} end)
@@ -444,10 +444,12 @@ defmodule KinoVegaLite.ChartCell do
     Enum.map(data, fn data -> data |> Enum.at(0) |> type_of() end)
   end
 
-  defp infer_types({:rows, %{columns: _columns}, data}) do
-    data
-    |> Enum.at(0)
-    |> Enum.map(&type_of/1)
+
+  defp infer_types({:rows, %{columns: columns}, data}) do
+    case Enum.fetch(data, 0) do
+      {:ok, row} -> Enum.map(row, &type_of/1)
+      :error -> Enum.map(columns, fn _ -> nil end)
+    end
   end
 
   defp type_of(%mod{}) when mod in [Decimal], do: "quantitative"


### PR DESCRIPTION
If you create a Chart smart cell while some of your bindings are for datasets with no results then the Chart cell fails to work.  That is, you cannot choose any dataset in the "Data" input field.  The problem is that the private function `infer_types` encounters an error because for the :rows case because it assumes there is at least one row.

The solution here is to explicitly check for whether the dataset has data.  This does mean that a result set with no data won't be offered as a choice in the Chart smart cell.  I could see instead having `infer_types()` return a list matching the length of the columns, but with either `nil` or `"nominal"` for each value so that the dataset would be allowed when empty.