### PR TITLE
Align arrows and move bin to last

### DIFF
--- a/lib/assets/chart_cell/main.css
+++ b/lib/assets/chart_cell/main.css
@@ -118,9 +118,10 @@ input[type=number] {
 .inner-field .input {
   border: none;
   background-color: transparent;
-  background-position: center right 5px;;
+  background-position: center right 0px;
+  cursor: pointer;
   text-align: right;
-  padding-right: 23px;
+  padding-right: 14px;
 }
 
 .field-with-settings {
@@ -346,7 +347,7 @@ input::-webkit-inner-spin-button {
 }
 
 .field-settings-container {
-  padding: 8px 6px;
+  padding: 6px 9px;
   border-radius: 0.5rem;
   margin-bottom: 4px;
   border: 1px solid var(--gray-200);

--- a/lib/assets/chart_cell/main.js
+++ b/lib/assets/chart_cell/main.js
@@ -114,20 +114,20 @@ export function init(ctx, payload) {
                           :disabled="!hasDataField(layer.x_field)"
                           :inner
                         />
-                        <BaseSwitch
-                          name="x_field_bin"
-                          label="Bin"
-                          :layer="index"
-                          v-model="layer.x_field_bin"
-                          :disabled="!hasDataField(layer.x_field)"
-                          :inner
-                        />
                         <BaseSelect
                           name="x_field_scale_type"
                           label="Scale"
                           :layer="index"
                           v-model="layer.x_field_scale_type"
                           :options="scaleOptions"
+                          :disabled="!hasDataField(layer.x_field)"
+                          :inner
+                        />
+                        <BaseSwitch
+                          name="x_field_bin"
+                          label="Bin"
+                          :layer="index"
+                          v-model="layer.x_field_bin"
                           :disabled="!hasDataField(layer.x_field)"
                           :inner
                         />
@@ -165,21 +165,21 @@ export function init(ctx, payload) {
                           :disabled="!hasDataField(layer.y_field)"
                           :inner
                         />
-                        <BaseSwitch
-                          name="y_field_bin"
-                          label="Bin"
-                          :layer="index"
-                          v-model="layer.y_field_bin"
-                          :inner
-                          :disabled="!hasDataField(layer.y_field)"
-                          :inner
-                        />
                         <BaseSelect
                           name="y_field_scale_type"
                           label="Scale"
                           :layer="index"
                           v-model="layer.y_field_scale_type"
                           :options="scaleOptions"
+                          :disabled="!hasDataField(layer.y_field)"
+                          :inner
+                        />
+                        <BaseSwitch
+                          name="y_field_bin"
+                          label="Bin"
+                          :layer="index"
+                          v-model="layer.y_field_bin"
+                          :inner
                           :disabled="!hasDataField(layer.y_field)"
                           :inner
                         />
@@ -217,21 +217,21 @@ export function init(ctx, payload) {
                           :disabled="!hasDataField(layer.color_field)"
                           :inner
                         />
-                        <BaseSwitch
-                          name="color_field_bin"
-                          label="Bin"
-                          :layer="index"
-                          v-model="layer.color_field_bin"
-                          :inner
-                          :disabled="!hasDataField(layer.color_field)"
-                          :inner
-                        />
                         <BaseSelect
                           name="color_field_scale_scheme"
                           label="Scheme"
                           :layer="index"
                           v-model="layer.color_field_scale_scheme"
                           :options="colorSchemeOptions"
+                          :disabled="!hasDataField(layer.color_field)"
+                          :inner
+                        />
+                        <BaseSwitch
+                          name="color_field_bin"
+                          label="Bin"
+                          :layer="index"
+                          v-model="layer.color_field_bin"
+                          :inner
                           :disabled="!hasDataField(layer.color_field)"
                           :inner
                         />


### PR DESCRIPTION
I know that Color and Axis have different fields (Scale and Schema) but Bin as last reads better as it is a different input type.

I also tagged the select with a cursor pointers, otherwise the clickable area was not immediately clear.

<img width="849" alt="Screenshot 2022-10-27 at 22 27 44" src="https://user-images.githubusercontent.com/9582/198392782-c73d23c0-ee78-4f40-b0a4-cb64f37db9a3.png">
