### PR TITLE
Update sample data in the warning

### DIFF
--- a/lib/assets/chart_cell/main.js
+++ b/lib/assets/chart_cell/main.js
@@ -297,7 +297,7 @@ export function init(ctx, payload) {
         <div class="box box-warning" v-if="noDataVariable">
           <p>To successfully plot graphs, you need at least one dataset available.</p>
           <p>A dataset can be a map of series, for example:</p>
-          <pre><code>my_data = %{a: [89, 124, 09, 67, 45], b: [12, 45, 67, 83, 32]}</code></pre>
+          <pre><code>my_data = %{a: [89, 124, 0, 67, 45], b: [12, 45, 67, 83, 31]}</code></pre>
           <p>Or an <a href="https://github.com/elixir-nx/explorer" target="_blank">Explorer</a> dataframe:</p>
           <pre><code>iris = Explorer.Datasets.iris()</code></pre>
         </div>


### PR DESCRIPTION
By following the warning we end up with this data:

<img width="645" alt="image" src="https://user-images.githubusercontent.com/76071/225424695-f35e5b15-94b0-4dd9-b807-c0a5bd92ba90.png">

which might be surprising to new comers. Here we are adjusting the values so that we don't end up in the ASCII printable range.