### PR TITLE
Fix spelling error in documentation

### DIFF
--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -56,7 +56,7 @@ defmodule Kino.VegaLite do
       This option is useful when you are appending new
       data points to the plot over a long period of time
 
-    * `dataset` - name of the targetted dataset from
+    * `dataset` - name of the targeted dataset from
       the VegaLite specification. Defaults to the default
       anonymous dataset
 
@@ -91,7 +91,7 @@ defmodule Kino.VegaLite do
 
   ## Options
 
-    * `dataset` - name of the targetted dataset from
+    * `dataset` - name of the targeted dataset from
       the VegaLite specification. Defaults to the default
       anonymous dataset
 


### PR DESCRIPTION
I happened to notice this while reading the documentation. This PR changes the spelling of "targetted" to "targeted". I double-checked, and it is indeed spelled "targeted" in both British and American English. For example: https://dictionary.cambridge.org/us/dictionary/english/targeted