### PR TITLE
Allow disabling default livebook theme

### DIFF
--- a/assets/vega_lite/main.js
+++ b/assets/vega_lite/main.js
@@ -120,15 +120,17 @@ export function init(ctx, data) {
     "https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
   );
 
-  const { spec, datasets } = data;
+  const { spec, datasets, config } = data;
 
   if (!spec.data) {
     spec.data = { values: [] };
   }
 
+  let theme = config.theme === "livebook" ? livebookTheme : {};
+
   const options = {
     actions: { export: true, source: false, compiled: false, editor: false },
-    config: livebookTheme,
+    config: theme,
   };
 
   vegaEmbed(ctx.root, spec, options)

--- a/test/kino/vega_lite_test.exs
+++ b/test/kino/vega_lite_test.exs
@@ -93,6 +93,27 @@ defmodule Kino.VegaLiteTest do
     assert_broadcast_event(kino, "push", %{data: [], dataset: nil, window: 0})
   end
 
+  test "configure/2" do
+    # with invalid theme
+    assert_raise ArgumentError,
+                 "expected :theme to be either :livebook or nil, got: :invalid",
+                 fn -> Kino.VegaLite.configure(theme: :invalid) end
+
+    # with default theme
+    kino = start_kino()
+
+    data = connect(kino)
+    assert %{config: %{theme: :livebook}} = data
+
+    # with empty theme
+    Kino.VegaLite.configure(theme: nil)
+
+    kino = start_kino()
+
+    data = connect(kino)
+    assert %{config: %{theme: nil}} = data
+  end
+
   defp start_kino() do
     Vl.new()
     |> Vl.mark(:point)


### PR DESCRIPTION
By default the look is the same as before:

<img width="477" alt="image" src="https://github.com/livebook-dev/kino_vega_lite/assets/1561963/f2c04e3d-2c38-4afa-bfab-e544b8d3b54b">

With theme disabled:

<img width="482" alt="image" src="https://github.com/livebook-dev/kino_vega_lite/assets/1561963/20f3e247-aae7-485a-8277-6887f0f7c9a5">

--------------

With default theme and tucan dark theme (the axes labels are not visible since they are overridden by the default theme):

<img width="516" alt="image" src="https://github.com/livebook-dev/kino_vega_lite/assets/1561963/4365445b-4368-4cf6-b4e0-8452dfc0df11">

With theme disabled and tucan dark theme:

<img width="480" alt="image" src="https://github.com/livebook-dev/kino_vega_lite/assets/1561963/e1203550-6b9b-4c5c-9994-c8cdfad2b457">


Closes #55