### PR TITLE
Enable vega-embed actions

### DIFF
--- a/assets/vega_lite/main.js
+++ b/assets/vega_lite/main.js
@@ -129,7 +129,7 @@ export function init(ctx, data) {
   let theme = config.theme === "livebook" ? livebookTheme : {};
 
   const options = {
-    actions: { export: true, source: false, compiled: false, editor: false },
+    actions: { export: true, source: true, compiled: false, editor: true },
     config: theme,
   };
 


### PR DESCRIPTION
~Now that we have `configure` we can also configure if the vega embed actions will be visible:~

<img width="862" alt="image" src="https://github.com/livebook-dev/kino_vega_lite/assets/1561963/0a848b09-e9e8-4638-8119-11b4308ab1ee">

**UPDATE**

Actions enabled by default